### PR TITLE
add possibility to override webpack config at plugin level

### DIFF
--- a/packages/cerebro-scripts/config/paths.js
+++ b/packages/cerebro-scripts/config/paths.js
@@ -1,12 +1,19 @@
 'use strict';
 
 const path = require('path')
+const fs = require('fs')
 
 const pluginPath = path.resolve()
 const dist = path.resolve('dist')
 
 const webpackBin = path.join(__dirname, '..', 'node_modules', '.bin', 'webpack')
-const webpackConfig = path.join(__dirname, '..', 'config', 'webpack.config.js')
+
+let webpackConfig = ''
+if (fs.existsSync(path.join(pluginPath, 'webpack.config.js'))) {
+	webpackConfig = path.join(pluginPath, 'webpack.config.js')
+} else {
+	webpackConfig = path.join(__dirname, '..', 'config', 'webpack.config.js')
+}
 
 const babiliBin = path.join(__dirname, '..', 'node_modules', '.bin', 'babili')
 


### PR DESCRIPTION
When creating a plugin I felt the need to add some extra configurations to the default webpack config.
This PR, makes Cerebro use a custom webpack config, if a webpack.config.js is found on plugin root directory.